### PR TITLE
override api-request-url scheme if proxy proto is set

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -31,6 +31,7 @@ func ListenAndServe(provider model.PipelineProvider, errChan chan bool) {
 	Preset(provider)
 	InitAgent(server)
 	router := http.Handler(NewRouter(server))
+	router = proxyProtoHandler(router)
 	router = handlers.LoggingHandler(os.Stdout, router)
 	router = handlers.ProxyHeaders(router)
 	if err := http.ListenAndServe(":60080", router); err != nil {


### PR DESCRIPTION
To fix: https://github.com/rancher/rancher/issues/13401
The cause is that in the api package the `api-request-url` header takes precedence over the standard proxy headers, but its scheme is not properly set in the case of SSL termination at the proxy.
After this is merged, an update on UI side is needed because it does not fetch logs via wss in this case.