### PR TITLE
move gitlab API to v4

### DIFF
--- a/scm/gitlab_manager.go
+++ b/scm/gitlab_manager.go
@@ -18,8 +18,8 @@ import (
 	"golang.org/x/oauth2"
 )
 
-//use v3 endpoint for compatibility
-const gitlabAPI = "%s%s/api/v3"
+//use v4 api endpoint
+const gitlabAPI = "%s%s/api/v4"
 
 type GitlabManager struct {
 	host   string


### PR DESCRIPTION
To fix: https://github.com/rancher/pipeline/issues/48
it's time to move to gitlab v4 API, as v3 is deprecated now.